### PR TITLE
Fix typo in py_interface license: LGPL

### DIFF
--- a/docs/source/interfacing.rst
+++ b/docs/source/interfacing.rst
@@ -39,7 +39,7 @@ Python
 *   py_interface
     `Website <http://www.lysator.liu.se/~tab/erlang/py_interface/>`_,
     `Github <git://github.com/tomas-abrahamsson/py_interface.git>`_
-    (license GPL)
+    (license LGPL)
 *   PyErl `Github <https://github.com/hamano/python-erlang-interface>`_ (license ?)
 
 Ruby


### PR DESCRIPTION
Hi, first thanks for some nice writings! Just wanted to contribute with fixing a tiny typo about the license of `py_interface`: LGPL, not GPL.