### PR TITLE
The ImpT chunk keeps functions from other modules

### DIFF
--- a/docs/source/indepth-beam-file.rst
+++ b/docs/source/indepth-beam-file.rst
@@ -121,7 +121,7 @@ A better reference is in the
 "ImpT" - Imports Table
 ``````````````````````
 
-Encodes imported functions in the ``-import([]).`` attribute.
+Encodes functions from other modules invoked by the current module.
 
 * Read U32/big count
 


### PR DESCRIPTION
I believe I found a tiny error. ImpT does not keep `-import([]).` but rather all of the functions from other modules we invoke, regardless of how (impored or not).

Thanks for the fantastic resource! 